### PR TITLE
feat: Initial stab at a remote/rotating JWT plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules/
+artifacts/
+features/*.feature

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,1 @@
+extends: screwdriver

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+artifacts/
+npm-debug.log
+.DS_STORE
+.*.swp

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+ci/
+.editorconfig
+eslint*
+CONTRIBUTING.md
+screwdriver.yaml
+test/
+features/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to Screwdriver
+
+Have a look at our guidelines, as well as pointers on where to start making changes, in our official [documentation](http://docs.screwdriver.cd/about/contributing).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2017 Yahoo Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Yahoo! Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,142 @@
-# hapi-auth-dynamic-jwt
-Hapi plugin to authenticate using remote keys and issue JSON Web Tokens based on rotating secrets
+# Hapi Auth Dynamic JWT
+[![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
+
+> Hapi plugin to authenticate and issue JSON Web Tokens based on rotating secrets
+
+## Why
+
+This plugin was written to solve two scenarios:
+
+1. An attacker gains access to a copy of our private signing key.  We need to rotate the credential as fast as possible as well as update all downstream services to get our new key.  This plugin allows the downstream services to dynamically load the active keys.
+
+2. We rotate our secrets on a regular basis (good practice).  When we do, existing JWTs in-flight would be invalidated (bad user experience).  This plugin allows us to preload multiple time-limited signing keys so that secrets are periodically rotated and JWTs that are issued will be guaranteed to be valid for their lifespan.
+
+## Features
+
+ - [X] Validates against multiple keys (with expiration)
+ - [X] Exposes function to create new JWT based on TTL
+ - [X] Exposes list of keys, expiration, and type
+ - [X] Loads keys from remote server
+ - [X] Reloads remote keys if key id not found
+ - [X] Customizable timeout
+ - [X] Customize issuer name
+ - [X] Uses semaphore to prevent concurrent requests
+ - [ ] Supports exposing Realm and requested Scope
+
+## Usage
+
+```bash
+npm install --save hapi-auth-dynamic-jwt
+```
+
+### Configuration
+
+There are two different modes to be in: server and remote.  Server-mode means it will host the private keys and can issue JWTs.  Remote-mode means it will validate JWTs against the public keys published from a server.
+
+When providing keys for server-mode, these are the fields required:
+
+ - `private`: Private key to sign JWTs
+ - `public`: Public key to verify JWTs signed with the private key
+ - `algorithm`: The key's algorithm, one of the ones on https://www.npmjs.com/package/jwa
+ - `expires`: Unix timestamp it should expire at
+
+### Example Auth Server
+
+```js
+const Hapi = require('hapi');
+const server = new Hapi.Server();
+
+server.connection({ port: 12345 });
+server.register({
+    register: require('hapi-auth-dynamic-jwt'),
+    options: {
+        keys: require('./keys.json'),
+        maxAge: '1h'
+    }
+}).then(() => {
+    server.auth.strategy('default', 'dynamic-jwt');
+    server.route({
+        method: 'GET',
+        path: '/protected-route',
+        config: {
+            auth: 'default',
+            handler: (request, reply) => reply(request.auth.credentials)
+        }
+    });
+    server.route({
+        method: 'GET',
+        path: '/keys',
+        config: {
+            handler: (request, reply) =>
+                reply(server.plugins['hapi-auth-dynamic-jwt'].availableKeys())
+        }
+    });
+    server.route({
+        method: 'GET',
+        path: '/new-jwt',
+        config: {
+            handler: (request, reply) =>
+                reply(server.plugins['hapi-auth-dynamic-jwt'].createJWT({
+                    subject: 'Bean',
+                    payload: {
+                        entity: {
+                            fullname: 'Mr. Bean',
+                            address: '12 Arbor Road, London'
+                        }
+                    },
+                    scope: [
+                        'admin'
+                    ],
+                    time: '5m'
+                }))
+        }
+    });
+});
+```
+
+### Example Auth Remote
+
+```js
+const Hapi = require('hapi');
+const server = new Hapi.Server();
+
+server.connection({ port: 12345 });
+server.register({
+    register: require('hapi-auth-dynamic-jwt'),
+    options: {
+        remoteUri: 'https://example.com/keys',
+        timeout: 1
+    }
+}).then(() => {
+    server.auth.strategy('default', 'dynamic-jwt');
+    server.route({
+        method: 'GET',
+        path: '/protected-route',
+        config: {
+            auth: 'default',
+            handler: (request, reply) => reply(request.auth.credentials)
+        }
+    });
+});
+```
+
+## Testing
+
+```bash
+npm test
+```
+
+## License
+
+Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
+
+[npm-image]: https://img.shields.io/npm/v/hapi-auth-dynamic-jwt.svg
+[npm-url]: https://npmjs.org/package/hapi-auth-dynamic-jwt
+[downloads-image]: https://img.shields.io/npm/dt/hapi-auth-dynamic-jwt.svg
+[license-image]: https://img.shields.io/npm/l/hapi-auth-dynamic-jwt.svg
+[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/hapi-auth-dynamic-jwt.svg
+[issues-url]: https://github.com/screwdriver-cd/hapi-auth-dynamic-jwt/issues
+[status-image]: https://cd.screwdriver.cd/pipelines/360/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/360
+[daviddm-image]: https://david-dm.org/screwdriver-cd/hapi-auth-dynamic-jwt.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/screwdriver-cd/hapi-auth-dynamic-jwt

--- a/index.js
+++ b/index.js
@@ -1,0 +1,375 @@
+'use strict';
+
+// @NOTE this module is styled based on http://hapijs.com/styleguide
+
+const Boom = require('boom');
+const Joi = require('joi');
+const Jwt = require('jsonwebtoken');
+const ms = require('ms');
+const os = require('os');
+const guid = require('aguid');
+const request = require('request');
+const semaphore = require('semaphore');
+const pkg = require('./package.json');
+const internals = {};
+
+internals.REGEX_BEARER = /Bearer\s+(.+)$/i;
+internals.SCHEMA_KEY = Joi.object({
+    private: Joi.string()
+        .required()
+        .label('Private Key'),
+    public: Joi.string()
+        .required()
+        .label('Public Key'),
+    algorithm: Joi.string()
+        .required()
+        .label('Algorithm from https://www.npmjs.com/package/jwa'),
+    expires: Joi.number()
+        .integer().positive()
+        .required()
+        .label('UNIX Timestamp for key expiration')
+});
+
+internals.SCHEMA_LOCAL_KEYS = Joi.array()
+    .min(1).items(internals.SCHEMA_KEY)
+    .required()
+    .label('List of private keys');
+internals.SCHEMA_AGE = Joi.string()
+    .default('12h')
+    .optional()
+    .label('Maximum JWT age');
+internals.SCHEMA_ISSUER = Joi.string()
+    .default(os.hostname())
+    .optional()
+    .label('Host that issues the JWT');
+internals.SCHEMA_LOCAL_CONFIG = Joi.object({
+    keys: internals.SCHEMA_LOCAL_KEYS,
+    maxAge: internals.SCHEMA_AGE,
+    issuer: internals.SCHEMA_ISSUER
+}).required().label('Source-of-Truth Config');
+
+internals.SCHEMA_REMOTE_URI = Joi.string()
+    .uri()
+    .required()
+    .label('Remote URI for public keys');
+internals.SCHEMA_TIMEOUT = Joi.number()
+    .integer().positive()
+    .default('5')
+    .optional()
+    .label('Timeout loading remote keys');
+internals.SCHEMA_REMOTE_CONFIG = Joi.object({
+    remoteUri: internals.SCHEMA_REMOTE_URI,
+    timeout: internals.SCHEMA_TIMEOUT
+}).required().label('Remote Config');
+
+internals.SCHEMA_KEYS = Joi.alternatives(
+    internals.SCHEMA_LOCAL_CONFIG,
+    internals.SCHEMA_REMOTE_CONFIG
+).required().label('List of private keys or Remote URI for public keys');
+
+internals.SCHEMA_CREATE = Joi.object({
+    subject: Joi.string()
+        .required()
+        .label('Subject of the JWT'),
+    payload: Joi.object()
+        .required()
+        .label('Describing attributes about the subject'),
+    scope: Joi.array()
+        .default([])
+        .label('List of permissions applied to this JWT'),
+    time: Joi.string()
+        .required()
+        .label('Life of JWT')
+}).required();
+
+/**
+ * Creates a Source-of-Truth auth services
+ * @method loadLocal
+ * @param  {Object}  authConfig         Input for setting up a local version
+ * @param  {Array}   authConfig.keys    List of public/private keys
+ * @param  {String}  authConfig.maxAge  Maximum age of JWTs
+ * @param  {String}  authConfig.issuer  Name of issuing server
+ * @return {Object}                     API to expose and getKey function
+ */
+internals.loadLocal = (authConfig) => {
+    const keys = {};
+
+    authConfig.keys.forEach((key) => {
+        keys[guid(key.public)] = key;
+    });
+
+    const expireIds = Object.keys(keys).sort((keyA, keyB) =>
+        keys[keyA].expires - keys[keyB].expires
+    );
+
+    return {
+        /**
+        * Load the key data
+        * @method getKey
+        * @param  {String}   keyId Key you are looking for
+        * @param  {Function} next  Function to call when done (error, key)
+        */
+        getKey: (keyId, next) => {
+            if (keys[keyId]) {
+                return next(null, keys[keyId]);
+            }
+
+            return next(new Error('Specified Key Id not found'));
+        },
+
+        /**
+         * Exposed API for the auth plugin
+         * @type {Object}
+         */
+        api: {
+            /**
+             * Create new JWT based on the available keys
+             * @method createJWT
+             * @param  {Object}  jwtConfig
+             * @param  {String}  jwtConfig.subject Thing that this represents
+             * @param  {Object}  jwtConfig.payload Attributes about the subject
+             * @param  {Array}   jwtConfig.scope   List of privileges
+             * @param  {String}  jwtConfig.time    How long the credential will last
+             * @return {String}                    Signed JSON Web Token
+             */
+            createJWT: (jwtConfig) => {
+                const parsedConfig = Joi.attempt(jwtConfig, internals.SCHEMA_CREATE,
+                    'Invalid JWT options');
+
+                if (ms(parsedConfig.time) > ms(authConfig.maxAge)) {
+                    throw new Error('Request exceeds max JWT age');
+                }
+
+                // Find the first key that expires AFTER the requested length of the key
+                const signingKeyId = Object.keys(keys).find(keyId =>
+                    (ms(parsedConfig.time) + Date.now()) / 1000 < keys[keyId].expires
+                );
+                const signingKey = keys[signingKeyId];
+
+                if (!signingKey) {
+                    throw new Error('No valid key exists to support this time range');
+                }
+
+                // Ensure that scope is included in the payload
+                const payload = jwtConfig.payload;
+
+                payload.scope = parsedConfig.scope;
+
+                return Jwt.sign(payload, signingKey.private, {
+                    algorithm: signingKey.algorithm,
+                    expiresIn: parsedConfig.time,
+                    notBefore: 0,
+                    issuer: authConfig.issuer,
+                    jwtid: guid(),
+                    keyid: signingKeyId,
+                    subject: parsedConfig.subject
+                });
+            },
+
+            /**
+             * List only the active keys (no larger than maxAge)
+             * @method availableKeys
+             * @return {Object}      KeyId => public, expire, algorithm
+             */
+            availableKeys: () => {
+                const nowDate = Date.now() / 1000;
+                const maxDate = nowDate + (ms(authConfig.maxAge) / 1000);
+                const output = {};
+
+                expireIds.some((keyId) => {
+                    if (nowDate > keys[keyId].expires) {
+                        return false;
+                    }
+
+                    if (maxDate > keys[keyId].expires) {
+                        return false;
+                    }
+
+                    output[keyId] = {
+                        public: keys[keyId].public,
+                        algorithm: keys[keyId].algorithm,
+                        expires: keys[keyId].expires
+                    };
+
+                    return true;
+                });
+
+                return output;
+            }
+        }
+    };
+};
+
+/**
+ * Creates a Remote auth service
+ * @method loadRemote
+ * @param  {Object}  authConfig           Input for setting up a remote version
+ * @param  {String}  authConfig.remoteUri URI of remote server
+ * @param  {String}  authConfig.timeout   How long to wait for API response
+ * @param  {String}  authConfig.issuer    Name of issuing server
+ * @return {Object}                       Contains keys, apis, etc.
+ */
+internals.loadRemote = (authConfig) => {
+    const mutex = semaphore(1);
+    let keys = {};
+
+    return {
+        /**
+         * Load the key data (from the remote server if needed)
+         * @method getKey
+         * @param  {String}   keyId Key you are looking for
+         * @param  {Function} next  Function to call when done (error, key)
+         */
+        getKey: (keyId, next) => {
+            const nextSem = (err, result) => {
+                mutex.leave();
+                next(err, result);
+            };
+
+            // Prevent multiple calls to the remote URI
+            mutex.take(() => {
+                if (keys[keyId]) {
+                    return nextSem(null, keys[keyId]);
+                }
+
+                return request({
+                    url: authConfig.remoteUri,
+                    headers: {
+                        'user-agent': `${pkg.name}@${pkg.version}`,
+                        'hapi-auth-requested-key': keyId
+                    },
+                    json: true,
+                    timeout: authConfig.timeout
+                }, (reqError, response, body) => {
+                    if (reqError || response.statusCode !== 200) {
+                        const prevError = reqError ||
+                            new Error(`Status Code: ${response.statusCode}`);
+
+                        return nextSem(prevError);
+                    }
+
+                    keys = {};
+                    body.forEach((key) => {
+                        keys[guid(key.public)] = key;
+                    });
+
+                    if (keys[keyId]) {
+                        return nextSem(null, keys[keyId]);
+                    }
+
+                    return nextSem(new Error('Specified Key Id not found'));
+                });
+            });
+        }
+    };
+};
+
+/**
+ * Configures the authentication plugin of Hapi
+ * @method implementation
+ * @param  {HapiServer} server           HapiServer we are attaching the auth service to
+ * @param  {Object}     config           Plugin configuration
+ * @param  {Array}      config.keys      List of private keys to sign JWTs with
+ * @param  {String}     config.maxAge    Maximum age for signing JWTs
+ * @param  {String}     config.remoteUri URI of remote keys
+ * @param  {String}     config.timeout   How long to wait for API response
+ * @param  {String}     config.issuer    Name of issuing server
+ * @return {Object}                      Contains an authenticate function to parse each request
+ */
+internals.implementation = (server, config) => {
+    const authConfig = Joi.attempt(config, internals.SCHEMA_KEYS,
+        'Invalid config for hapi-auth-dynamic-jwt plugin');
+    let authObject = {};
+
+    // Local mode
+    if (typeof authConfig.keys === 'object') {
+        authObject = internals.loadLocal(authConfig);
+    } else {
+        authObject = internals.loadRemote(authConfig);
+    }
+
+    return {
+        api: authObject.api,
+
+        /**
+         * Replies with the parsed credentials or an error based on the input from request
+         * @method authenticate
+         * @param  {HapiRequest}   req     Route handler request object
+         * @param  {HapiReply}     reply   Reply interface
+         * @return {Function}              Result of Reply interface
+         */
+        authenticate: (req, reply) => {
+            const parsedHeader = internals.REGEX_BEARER.exec(req.headers.authorization);
+
+            /**
+             * Reply with a unauthorized error message
+             * @method replyError
+             * @param  {String}    message Error message
+             * @return {Promise}
+             */
+            const replyError = message =>
+                reply(Boom.unauthorized(null, 'Bearer', {
+                    error: message
+                }));
+
+            // Ensure we have the header
+            if (!parsedHeader) {
+                return replyError('Missing JWT');
+            }
+
+            const token = parsedHeader[1];
+            const credentials = Jwt.decode(token);
+
+            // Check if it's valid JWT
+            if (!credentials) {
+                return replyError('Invalid JWT format');
+            }
+
+            // Ensure we have the key requested
+            return authObject.getKey(credentials.kid, (keyError, signingKey) => {
+                if (keyError) {
+                    server.log(['auth', 'error', req.name], keyError.toString());
+
+                    return replyError('Unknown JWT public key ID');
+                }
+
+                // Check if the key is expired
+                if (signingKey.expires < Date.now() / 1000) {
+                    return replyError('JWT key has expired');
+                }
+
+                // Verify the signature
+                try {
+                    Jwt.verify(token, signingKey.public, {
+                        algorithms: [signingKey.algorithm]
+                    });
+                } catch (jwtError) {
+                    return replyError(`Invalid JWT signature: ${jwtError.toString()}`);
+                }
+
+                return reply.continue({ credentials });
+            });
+        }
+    };
+};
+
+/**
+ * Registers the auth plugin and required routes
+ * @see http://hapijs.com/api#serverplugins
+ * @method register
+ * @param  {HapiServer}  server  Hapi Server we are attaching this plugin to
+ * @param  {Object}      options Configuration for the plugin
+ * @param  {Function}    next    Callback once registration succeeds
+ */
+exports.register = (server, options, next) => {
+    // Configure authentication
+    server.auth.scheme('dynamic-jwt', internals.implementation);
+
+    return process.nextTick(next);
+};
+
+/**
+ * Exposes the package name and version number to Hapi
+ * @type {Object}
+ */
+exports.register.attributes = { pkg };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "hapi-auth-dynamic-jwt",
+  "version": "1.0.0",
+  "description": "Hapi plugin to authenticate and issue JSON Web Tokens based on rotating secrets",
+  "main": "index.js",
+  "scripts": {
+    "pretest": "eslint .",
+    "test": "jenkins-mocha --recursive",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:screwdriver-cd/hapi-auth-dynamic-jwt.git"
+  },
+  "homepage": "https://github.com/screwdriver-cd/hapi-auth-dynamic-jwt",
+  "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
+  "keywords": [
+    "screwdriver",
+    "yahoo"
+  ],
+  "license": "BSD-3-Clause",
+  "author": "St. John Johnson <st.john.johnson@gmail.com>",
+  "contributors": [
+    "Dao Lam <daolam112@gmail.com>",
+    "Darren Matsumoto <aeneascorrupt@gmail.com>",
+    "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
+    "Jithin Emmanuel <jithin1987@gmail.com>",
+    "Min Zhang <minzhang@andrew.cmu.edu>",
+    "Peter Peterson <jedipetey@gmail.com>",
+    "St. John Johnson <st.john.johnson@gmail.com",
+    "Tiffany Kyi <tiffanykyi@gmail.com>"
+  ],
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
+    "eslint": "^4.9.0",
+    "eslint-config-screwdriver": "^3.0.0",
+    "hapi": "^16.6.2",
+    "jenkins-mocha": "^5.0.0",
+    "mockery": "^2.1.0",
+    "nock": "^9.0.22",
+    "sinon": "^4.0.1"
+  },
+  "dependencies": {
+    "aguid": "^2.0.0",
+    "boom": "^6.0.0",
+    "joi": "^13.0.0",
+    "jsonwebtoken": "^8.1.0",
+    "ms": "^2.0.0",
+    "request": "^2.83.0",
+    "semaphore": "^1.1.0"
+  }
+}

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,19 @@
+workflow:
+    - publish
+
+shared:
+    image: node:6
+
+jobs:
+    main:
+        steps:
+            - install: npm install
+            - test: npm test
+
+    publish:
+        template: screwdriver-cd/semantic-release
+        secrets:
+            # Publishing to NPM
+            - NPM_TOKEN
+            # Pushing tags to Git
+            - GH_TOKEN

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,682 @@
+'use strict';
+
+const hapi = require('hapi');
+const chai = require('chai');
+const mockery = require('mockery');
+const sinon = require('sinon');
+const ms = require('ms');
+const nock = require('nock');
+const assert = chai.assert;
+
+chai.use(require('chai-as-promised'));
+
+sinon.assert.expose(chai.assert, { prefix: '' });
+
+/**
+ * Generates a random key to provide to the input
+ * @method randomKey
+ * @param  {String}  expiresIn     Time before expires
+ * @param  {Boolean} [isNegative]  Make the time negative
+ * @param  {Boolean} [skipPrivate] Ignore private keys
+ * @return {Object}                Key format needed by the plugin
+ */
+function randomKey(expiresIn, isNegative, skipPrivate) {
+    let expires = ms(expiresIn || '5m');
+
+    if (isNegative) {
+        expires *= -1;
+    }
+
+    const key = {
+        private: `FAKE_PRIVATE_KEY1${expires}`,
+        public: `FAKE_PUBLIC_KEY1${expires}`,
+        algorithm: 'es512',
+        expires: Math.floor((Date.now() + expires) / 1000)
+    };
+
+    if (skipPrivate) {
+        delete key.private;
+    }
+
+    return key;
+}
+
+describe('hapi-auth-dynamic-jwt test', () => {
+    let plugin;
+    let server;
+    let jwtMock;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        jwtMock = {
+            verify: sinon.stub(),
+            decode: sinon.stub(),
+            sign: sinon.stub()
+        };
+        mockery.registerMock('jsonwebtoken', jwtMock);
+
+        nock.disableNetConnect();
+
+        /* eslint-disable global-require */
+        plugin = require('../index');
+        /* eslint-enable global-require */
+        server = new hapi.Server();
+        server.connection({
+            port: 1234
+        });
+    });
+
+    afterEach(() => {
+        server = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+        nock.cleanAll();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('registration', () => {
+        it('registers the plugin', () =>
+            server.register(plugin).then(() =>
+                server.auth.strategy('default', 'dynamic-jwt', false, {
+                    keys: [randomKey()]
+                })
+            ).then(() => {
+                assert.property(server.registrations, 'hapi-auth-dynamic-jwt');
+            })
+        );
+
+        it('requires keys', () =>
+            server.register(plugin).then(() =>
+                server.auth.strategy('default', 'dynamic-jwt', false)
+            ).then(() =>
+                assert.fail()
+            ).catch(err => assert.match(err.toString(),
+                /"Source-of-Truth Config" must be an object/))
+        );
+
+        it('requires keys in the right format', () =>
+            server.register(plugin).then(() =>
+                server.auth.strategy('default', 'dynamic-jwt', false, {
+                    keys: [{}]
+                })
+            ).then(() =>
+                assert.fail()
+            ).catch(err => assert.match(err.toString(), /"Private Key" is required/))
+        );
+    });
+
+    describe('validation', () => {
+        beforeEach(() => server.register(plugin)
+            .then(() => server.auth.strategy('default', 'dynamic-jwt', false, {
+                keys: [randomKey(), randomKey('5m', true)]
+            }))
+        );
+
+        it('requires a JWT to be passed', () => {
+            server.route({
+                method: 'GET',
+                path: '/protected-route',
+                config: {
+                    auth: 'default',
+                    handler: (request, reply) => reply({})
+                }
+            });
+
+            return server.inject({
+                url: '/protected-route'
+            }).then((reply) => {
+                assert.equal(reply.statusCode, 401);
+                assert.property(reply.headers, 'www-authenticate');
+                assert.match(reply.headers['www-authenticate'], /Bearer/);
+                assert.match(reply.headers['www-authenticate'], /Missing JWT/);
+            });
+        });
+
+        it('requires a valid JWT to be passed', () => {
+            server.route({
+                method: 'GET',
+                path: '/protected-route',
+                config: {
+                    auth: 'default',
+                    handler: (request, reply) => reply({})
+                }
+            });
+            jwtMock.decode.returns(null);
+
+            return server.inject({
+                url: '/protected-route',
+                headers: {
+                    authorization: 'Bearer FOOBARBAZ'
+                }
+            }).then((reply) => {
+                assert.equal(reply.statusCode, 401);
+                assert.property(reply.headers, 'www-authenticate');
+                assert.match(reply.headers['www-authenticate'], /Bearer/);
+                assert.match(reply.headers['www-authenticate'], /Invalid JWT format/);
+            });
+        });
+
+        it('requires a matching key ID to be passed', () => {
+            server.route({
+                method: 'GET',
+                path: '/protected-route',
+                config: {
+                    auth: 'default',
+                    handler: (request, reply) => reply({})
+                }
+            });
+            jwtMock.decode.returns({
+                kid: 'f3907a3b-4d2e-426b-a9d5-111b35752d58'
+            });
+
+            return server.inject({
+                url: '/protected-route',
+                headers: {
+                    authorization: 'Bearer FOOBARBAZ'
+                }
+            }).then((reply) => {
+                assert.equal(reply.statusCode, 401);
+                assert.property(reply.headers, 'www-authenticate');
+                assert.match(reply.headers['www-authenticate'], /Bearer/);
+                assert.match(reply.headers['www-authenticate'], /Unknown JWT public key ID/);
+            });
+        });
+
+        it('fails if key is expired', () => {
+            server.route({
+                method: 'GET',
+                path: '/protected-route',
+                config: {
+                    auth: 'default',
+                    handler: (request, reply) => reply({})
+                }
+            });
+            jwtMock.decode.returns({
+                kid: 'dbe0be9b-4cb3-4bcc-8e27-16f8f52313e4'
+            });
+
+            return server.inject({
+                url: '/protected-route',
+                headers: {
+                    authorization: 'Bearer FOOBARBAZ'
+                }
+            }).then((reply) => {
+                assert.equal(reply.statusCode, 401);
+                assert.property(reply.headers, 'www-authenticate');
+                assert.match(reply.headers['www-authenticate'], /Bearer/);
+                assert.match(reply.headers['www-authenticate'], /JWT key has expired/);
+            });
+        });
+
+        it('requires a valid signed JWT to be passed', () => {
+            server.route({
+                method: 'GET',
+                path: '/protected-route',
+                config: {
+                    auth: 'default',
+                    handler: (request, reply) => reply({})
+                }
+            });
+            jwtMock.decode.returns({
+                kid: 'f8b86ef5-6f71-40bd-8add-529b4201834c'
+            });
+            jwtMock.verify.throws(new Error('Invalid JWT'));
+
+            return server.inject({
+                url: '/protected-route',
+                headers: {
+                    authorization: 'Bearer FOOBARBAZ'
+                }
+            }).then((reply) => {
+                assert.equal(reply.statusCode, 401);
+                assert.property(reply.headers, 'www-authenticate');
+                assert.match(reply.headers['www-authenticate'], /Bearer/);
+                assert.match(reply.headers['www-authenticate'], /Invalid JWT signature/);
+            });
+        });
+
+        it('returns credentials if passed', () => {
+            server.route({
+                method: 'GET',
+                path: '/protected-route',
+                config: {
+                    auth: 'default',
+                    handler: (request, reply) => reply(request.auth.credentials)
+                }
+            });
+            jwtMock.decode.returns({
+                kid: 'f8b86ef5-6f71-40bd-8add-529b4201834c',
+                sub: 'sample user'
+            });
+            jwtMock.verify.returns();
+
+            return server.inject({
+                url: '/protected-route',
+                headers: {
+                    authorization: 'Bearer FOOBARBAZ'
+                }
+            }).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.property(reply.result, 'sub');
+                assert.equal(reply.result.sub, 'sample user');
+            });
+        });
+    });
+
+    describe('create', () => {
+        beforeEach(() => server.register(plugin)
+            .then(() => server.auth.strategy('default', 'dynamic-jwt', false, {
+                keys: [randomKey('5s'), randomKey('5m')],
+                maxAge: '6h'
+            }))
+        );
+
+        it('fails if invalid conf', () => {
+            try {
+                server.auth.api.default.createJWT({});
+                assert.fail();
+            } catch (error) {
+                assert.match(error.toString(), /Invalid JWT options/);
+            }
+        });
+
+        it('picks appropriate key based on expire', () => {
+            jwtMock.sign.returns('aaaaaaaaaa.bbbbbbbbbbb.cccccccccccc');
+
+            assert.equal(server.auth.api.default.createJWT({
+                subject: 'foo',
+                payload: { a: 'b' },
+                scope: ['abc'],
+                time: '1s'
+            }), 'aaaaaaaaaa.bbbbbbbbbbb.cccccccccccc');
+            assert.calledWithMatch(jwtMock.sign,
+                {
+                    a: 'b',
+                    scope: ['abc']
+                },
+                'FAKE_PRIVATE_KEY15000',
+                {
+                    algorithm: 'es512',
+                    expiresIn: '1s',
+                    keyid: '0f2cadd8-69e0-42a9-8f46-b4722dcc722a',
+                    notBefore: 0,
+                    subject: 'foo'
+                }
+            );
+        });
+
+        it('fails if no valid keys available', () => {
+            try {
+                server.auth.api.default.createJWT({
+                    subject: 'foo',
+                    payload: { a: 'b' },
+                    scope: ['abc'],
+                    time: '5h'
+                });
+                assert.fail();
+            } catch (error) {
+                assert.match(error.toString(), /No valid key exists/);
+            }
+        });
+
+        it('fails if outside max age', () => {
+            try {
+                server.auth.api.default.createJWT({
+                    subject: 'foo',
+                    payload: { a: 'b' },
+                    scope: ['abc'],
+                    time: '6d'
+                });
+                assert.fail();
+            } catch (error) {
+                assert.match(error.toString(), /Request exceeds max JWT age/);
+            }
+        });
+
+        it('generates new credential', () => {
+            jwtMock.sign.returns('aaaaaaaaaa.bbbbbbbbbbb.cccccccccccc');
+
+            assert.equal(server.auth.api.default.createJWT({
+                subject: 'foo',
+                payload: { a: 'b' },
+                scope: ['abc'],
+                time: '1m'
+            }), 'aaaaaaaaaa.bbbbbbbbbbb.cccccccccccc');
+            assert.calledWithMatch(jwtMock.sign,
+                {
+                    a: 'b',
+                    scope: ['abc']
+                },
+                'FAKE_PRIVATE_KEY1300000',
+                {
+                    algorithm: 'es512',
+                    expiresIn: '1m',
+                    keyid: 'f8b86ef5-6f71-40bd-8add-529b4201834c',
+                    notBefore: 0,
+                    subject: 'foo'
+                }
+            );
+        });
+    });
+
+    describe('list', () => {
+        const keys = [randomKey('5s', true), randomKey('45s'), randomKey('5m'), randomKey('10m')];
+
+        beforeEach(() => server.register(plugin)
+            .then(() => server.auth.strategy('default', 'dynamic-jwt', false, {
+                maxAge: '1m',
+                keys
+            }))
+        );
+
+        it('lists just possibly active jwt keys', () => {
+            assert.deepEqual(server.auth.api.default.availableKeys(), {
+                'f8b86ef5-6f71-40bd-8add-529b4201834c': {
+                    public: 'FAKE_PUBLIC_KEY1300000',
+                    algorithm: 'es512',
+                    expires: keys[2].expires
+                }
+            });
+        });
+    });
+
+    describe('remote-keys', () => {
+        it('throws error if unable to load', () => {
+            nock('https://example.com')
+                .get('/keys')
+                .reply(404);
+
+            return server.register(plugin).then(() => {
+                server.auth.strategy('default', 'dynamic-jwt', false, {
+                    remoteUri: 'https://example.com/keys'
+                });
+                server.route({
+                    method: 'GET',
+                    path: '/protected-route',
+                    config: {
+                        auth: 'default',
+                        handler: (request, reply) => reply(request.auth.credentials)
+                    }
+                });
+                jwtMock.decode.returns({
+                    kid: 'f8b86ef5-6f71-40bd-8add-529b4201834c',
+                    sub: 'sample user'
+                });
+                jwtMock.verify.returns();
+
+                return server.inject({
+                    url: '/protected-route',
+                    headers: {
+                        authorization: 'Bearer FOOBARBAZ'
+                    }
+                }).then((reply) => {
+                    assert.equal(reply.statusCode, 401);
+                    assert.property(reply.headers, 'www-authenticate');
+                    assert.match(reply.headers['www-authenticate'], /Bearer/);
+                    assert.match(reply.headers['www-authenticate'], /Unknown JWT public key ID/);
+                });
+            });
+        });
+
+        it('throws error if bad response', () => {
+            nock('https://example.com')
+                .get('/keys')
+                .replyWithError('Oh No');
+
+            return server.register(plugin).then(() => {
+                server.auth.strategy('default', 'dynamic-jwt', false, {
+                    remoteUri: 'https://example.com/keys'
+                });
+                server.route({
+                    method: 'GET',
+                    path: '/protected-route',
+                    config: {
+                        auth: 'default',
+                        handler: (request, reply) => reply(request.auth.credentials)
+                    }
+                });
+                jwtMock.decode.returns({
+                    kid: 'f8b86ef5-6f71-40bd-8add-529b4201834c',
+                    sub: 'sample user'
+                });
+                jwtMock.verify.returns();
+
+                return server.inject({
+                    url: '/protected-route',
+                    headers: {
+                        authorization: 'Bearer FOOBARBAZ'
+                    }
+                }).then((reply) => {
+                    assert.equal(reply.statusCode, 401);
+                    assert.property(reply.headers, 'www-authenticate');
+                    assert.match(reply.headers['www-authenticate'], /Bearer/);
+                    assert.match(reply.headers['www-authenticate'], /Unknown JWT public key ID/);
+                });
+            });
+        });
+
+        it('returns credentials if passed', () => {
+            nock('https://example.com')
+                .get('/keys')
+                .reply(200, [
+                    randomKey('5s', false, true),
+                    randomKey('5m', false, true)
+                ]);
+
+            return server.register(plugin).then(() => {
+                server.auth.strategy('default', 'dynamic-jwt', false, {
+                    remoteUri: 'https://example.com/keys'
+                });
+                server.route({
+                    method: 'GET',
+                    path: '/protected-route',
+                    config: {
+                        auth: 'default',
+                        handler: (request, reply) => reply(request.auth.credentials)
+                    }
+                });
+                jwtMock.decode.returns({
+                    kid: 'f8b86ef5-6f71-40bd-8add-529b4201834c',
+                    sub: 'sample user'
+                });
+                jwtMock.verify.returns();
+
+                return server.inject({
+                    url: '/protected-route',
+                    headers: {
+                        authorization: 'Bearer FOOBARBAZ'
+                    }
+                }).then((reply) => {
+                    assert.equal(reply.statusCode, 200);
+                    assert.property(reply.result, 'sub');
+                    assert.equal(reply.result.sub, 'sample user');
+                });
+            });
+        });
+
+        it('returns cached key', () => {
+            nock('https://example.com')
+                .get('/keys')
+                .reply(200, [
+                    randomKey('5s', false, true),
+                    randomKey('5m', false, true)
+                ])
+                .get('/keys')
+                .reply(200, [
+                    randomKey('10s', false, true),
+                    randomKey('10m', false, true)
+                ]);
+
+            return server.register(plugin).then(() => {
+                server.auth.strategy('default', 'dynamic-jwt', false, {
+                    remoteUri: 'https://example.com/keys'
+                });
+                server.route({
+                    method: 'GET',
+                    path: '/protected-route',
+                    config: {
+                        auth: 'default',
+                        handler: (request, reply) => reply(request.auth.credentials)
+                    }
+                });
+                jwtMock.decode.returns({
+                    kid: 'f8b86ef5-6f71-40bd-8add-529b4201834c',
+                    sub: 'sample user'
+                });
+                jwtMock.verify.returns();
+
+                return server.inject({
+                    url: '/protected-route',
+                    headers: {
+                        authorization: 'Bearer FOOBARBAZ'
+                    }
+                }).then((reply) => {
+                    assert.equal(reply.statusCode, 200);
+                    assert.property(reply.result, 'sub');
+                    assert.equal(reply.result.sub, 'sample user');
+                }).then(() => server.inject({
+                    url: '/protected-route',
+                    headers: {
+                        authorization: 'Bearer FOOBARBAZ'
+                    }
+                })).then((reply) => {
+                    assert.equal(reply.statusCode, 200);
+                    assert.property(reply.result, 'sub');
+                    assert.equal(reply.result.sub, 'sample user');
+                });
+            });
+        });
+
+        it('fails if key not found after reload', () => {
+            nock('https://example.com')
+                .get('/keys')
+                .reply(200, [
+                    randomKey('5s', false, true),
+                    randomKey('5m', false, true)
+                ])
+                .get('/keys')
+                .reply(200, [
+                    randomKey('10s', false, true),
+                    randomKey('10m', false, true)
+                ]);
+
+            return server.register(plugin).then(() => {
+                server.auth.strategy('default', 'dynamic-jwt', false, {
+                    remoteUri: 'https://example.com/keys'
+                });
+                server.route({
+                    method: 'GET',
+                    path: '/protected-route',
+                    config: {
+                        auth: 'default',
+                        handler: (request, reply) => reply(request.auth.credentials)
+                    }
+                });
+                jwtMock.decode.returns({
+                    kid: '123c5121-185f-45b1-9bcb-e16c7c09517b',
+                    sub: 'sample user'
+                });
+                jwtMock.verify.returns();
+
+                return server.inject({
+                    url: '/protected-route',
+                    headers: {
+                        authorization: 'Bearer FOOBARBAZ'
+                    }
+                }).then((reply) => {
+                    assert.equal(reply.statusCode, 401);
+                    assert.property(reply.headers, 'www-authenticate');
+                    assert.match(reply.headers['www-authenticate'], /Bearer/);
+                    assert.match(reply.headers['www-authenticate'], /Unknown JWT public key ID/);
+                }).then(() => server.inject({
+                    url: '/protected-route',
+                    headers: {
+                        authorization: 'Bearer FOOBARBAZ'
+                    }
+                })).then((reply) => {
+                    assert.equal(reply.statusCode, 401);
+                    assert.property(reply.headers, 'www-authenticate');
+                    assert.match(reply.headers['www-authenticate'], /Bearer/);
+                    assert.match(reply.headers['www-authenticate'], /Unknown JWT public key ID/);
+                });
+            });
+        });
+
+        it('prevents duplicate calls', () => {
+            nock('https://example.com')
+                .get('/keys')
+                .reply(200, [
+                    randomKey('5s', false, true),
+                    randomKey('5m', false, true)
+                ])
+                .get('/keys')
+                .reply(404);
+
+            return server.register(plugin).then(() => {
+                server.auth.strategy('default', 'dynamic-jwt', false, {
+                    remoteUri: 'https://example.com/keys'
+                });
+                server.route({
+                    method: 'GET',
+                    path: '/protected-route',
+                    config: {
+                        auth: 'default',
+                        handler: (request, reply) => reply(request.auth.credentials)
+                    }
+                });
+                jwtMock.decode.returns({
+                    kid: 'f8b86ef5-6f71-40bd-8add-529b4201834c',
+                    sub: 'sample user'
+                });
+                jwtMock.verify.returns();
+
+                return Promise.all([
+                    server.inject({
+                        url: '/protected-route',
+                        headers: {
+                            authorization: 'Bearer FOOBARBAZ'
+                        }
+                    }),
+                    server.inject({
+                        url: '/protected-route',
+                        headers: {
+                            authorization: 'Bearer FOOBARBAZ'
+                        }
+                    })
+                ]).then((replies) => {
+                    replies.forEach((reply) => {
+                        assert.equal(reply.statusCode, 200);
+                        assert.property(reply.result, 'sub');
+                        assert.equal(reply.result.sub, 'sample user');
+                    });
+                });
+            });
+        });
+
+        it('does not expose createJWT or availableKeys', () => {
+            nock('https://example.com')
+                .get('/keys')
+                .reply(200, [
+                    randomKey('5s', false, true),
+                    randomKey('5m', false, true)
+                ]);
+
+            return server.register(plugin).then(() => {
+                server.auth.strategy('default', 'dynamic-jwt', false, {
+                    remoteUri: 'https://example.com/keys'
+                });
+                assert.notNestedProperty(server.auth.api, 'default.createJWT');
+                assert.notNestedProperty(server.auth.api, 'default.availableKeys');
+            });
+        });
+    });
+});


### PR DESCRIPTION
This JWT auth plugin is intended to replace `hapi-auth-jwt2` that we use in the API and Store server.  This plugin adds the following features:

 - All signing keys have an expiration
 - JWTs are issued based on those expirations
 - Remote servers can access the currently active public keys

[Related Issue](https://github.com/screwdriver-cd/screwdriver/issues/539)