### PR TITLE
feat: Remove `scope` from the `createJWT` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This plugin was written to solve two scenarios:
  - [X] Customizable timeout
  - [X] Customize issuer name
  - [X] Uses semaphore to prevent concurrent requests
- - [ ] Supports exposing Realm and requested Scope
 
 ## Usage
 
@@ -50,7 +49,20 @@ server.connection({ port: 12345 });
 server.register(require('hapi-auth-dynamic-jwt'))
 .then(() => {
     server.auth.strategy('default', 'dynamic-jwt', {
-        keys: require('./keys.json'),
+        keys: [
+            {
+                private: 'FAKE_PRIVATE_KEY1',
+                public: 'FAKE_PUBLIC_KEY2',
+                algorithm: 'es512',
+                expires: 1509480014
+            },
+            {
+                private: 'FAKE_PRIVATE_KEY2',
+                public: 'FAKE_PUBLIC_KEY2',
+                algorithm: 'es512',
+                expires: 1514209030
+            }
+        ],
         maxAge: '1h'
     });
     server.route({
@@ -80,11 +92,11 @@ server.register(require('hapi-auth-dynamic-jwt'))
                         entity: {
                             fullname: 'Mr. Bean',
                             address: '12 Arbor Road, London'
-                        }
+                        },
+                        scope: [
+                            'admin'
+                        ]
                     },
-                    scope: [
-                        'admin'
-                    ],
                     time: '5m'
                 }))
         }

--- a/index.js
+++ b/index.js
@@ -73,10 +73,7 @@ internals.SCHEMA_CREATE = Joi.object({
         .label('Subject of the JWT'),
     payload: Joi.object()
         .required()
-        .label('Describing attributes about the subject'),
-    scope: Joi.array()
-        .default([])
-        .label('List of permissions applied to this JWT'),
+        .label('Contents of the decoded JWT'),
     time: Joi.string()
         .required()
         .label('Life of JWT')
@@ -128,7 +125,6 @@ internals.loadLocal = (authConfig) => {
              * @param  {Object}  jwtConfig
              * @param  {String}  jwtConfig.subject Thing that this represents
              * @param  {Object}  jwtConfig.payload Attributes about the subject
-             * @param  {Array}   jwtConfig.scope   List of privileges
              * @param  {String}  jwtConfig.time    How long the credential will last
              * @return {String}                    Signed JSON Web Token
              */
@@ -150,12 +146,7 @@ internals.loadLocal = (authConfig) => {
                     throw new Error('No valid key exists to support this time range');
                 }
 
-                // Ensure that scope is included in the payload
-                const payload = jwtConfig.payload;
-
-                payload.scope = parsedConfig.scope;
-
-                return Jwt.sign(payload, signingKey.private, {
+                return Jwt.sign(parsedConfig.payload, signingKey.private, {
                     algorithm: signingKey.algorithm,
                     expiresIn: parsedConfig.time,
                     notBefore: 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-auth-dynamic-jwt",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Hapi plugin to authenticate and issue JSON Web Tokens based on rotating secrets",
   "main": "index.js",
   "scripts": {
@@ -11,6 +11,9 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:screwdriver-cd/hapi-auth-dynamic-jwt.git"
+  },
+  "engines": {
+    "node": ">=6"
   },
   "homepage": "https://github.com/screwdriver-cd/hapi-auth-dynamic-jwt",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -315,13 +315,11 @@ describe('hapi-auth-dynamic-jwt test', () => {
             assert.equal(server.auth.api.default.createJWT({
                 subject: 'foo',
                 payload: { a: 'b' },
-                scope: ['abc'],
                 time: '1s'
             }), 'aaaaaaaaaa.bbbbbbbbbbb.cccccccccccc');
             assert.calledWithMatch(jwtMock.sign,
                 {
-                    a: 'b',
-                    scope: ['abc']
+                    a: 'b'
                 },
                 'FAKE_PRIVATE_KEY15000',
                 {
@@ -339,7 +337,6 @@ describe('hapi-auth-dynamic-jwt test', () => {
                 server.auth.api.default.createJWT({
                     subject: 'foo',
                     payload: { a: 'b' },
-                    scope: ['abc'],
                     time: '5h'
                 });
                 assert.fail();
@@ -353,7 +350,6 @@ describe('hapi-auth-dynamic-jwt test', () => {
                 server.auth.api.default.createJWT({
                     subject: 'foo',
                     payload: { a: 'b' },
-                    scope: ['abc'],
                     time: '6d'
                 });
                 assert.fail();
@@ -368,13 +364,11 @@ describe('hapi-auth-dynamic-jwt test', () => {
             assert.equal(server.auth.api.default.createJWT({
                 subject: 'foo',
                 payload: { a: 'b' },
-                scope: ['abc'],
                 time: '1m'
             }), 'aaaaaaaaaa.bbbbbbbbbbb.cccccccccccc');
             assert.calledWithMatch(jwtMock.sign,
                 {
-                    a: 'b',
-                    scope: ['abc']
+                    a: 'b'
                 },
                 'FAKE_PRIVATE_KEY1300000',
                 {


### PR DESCRIPTION
**BREAKING CHANGE**

## Context

Removing `scope` from the object parameters because it is duplicating functionality.  Scope was being inserted into `payload` when instead the user should just be providing `scope` in `payload` anyway.  We have no reason to enforce `scope` at this level.

Also sets engine to >=6 (which is actually still supported).